### PR TITLE
fix flakey test which can inherit MDCs from other testcases

### DIFF
--- a/src/main/java/com/logcapture/LogCapture.java
+++ b/src/main/java/com/logcapture/LogCapture.java
@@ -3,6 +3,7 @@ package com.logcapture;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.logcapture.assertion.ExpectedLoggingMessage;
 import com.logcapture.assertion.VerificationException;
+import org.hamcrest.Matcher;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -18,11 +19,9 @@ public class LogCapture<T> {
     this.result = result;
   }
 
-  public LogCapture<T> logged(ExpectedLoggingMessage expectedLoggingMessage) {
-    for (ILoggingEvent event : events) {
-      if (expectedLoggingMessage.matches(event)) {
+  public LogCapture<T> logged(Matcher<List<ILoggingEvent>> expectedLoggingMessage) {
+      if (expectedLoggingMessage.matches(events)) {
         return this;
-      }
     }
 
     throw VerificationException.forUnmatchedLog(expectedLoggingMessage, events);

--- a/src/main/java/com/logcapture/assertion/VerificationException.java
+++ b/src/main/java/com/logcapture/assertion/VerificationException.java
@@ -1,6 +1,7 @@
 package com.logcapture.assertion;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.hamcrest.Matcher;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,9 +12,9 @@ public class VerificationException extends AssertionError {
     super(message);
   }
 
-  public static VerificationException forUnmatchedLog(ExpectedLoggingMessage expectedLogMessage, List<ILoggingEvent> logEvents) {
+  public static VerificationException forUnmatchedLog(Matcher<List<ILoggingEvent>> expectedLogMessage, List<ILoggingEvent> logEvents) {
     return new VerificationException(String.format(
-      "Expected at least one log matching: \n%s\nLogs received: \n%s",
+      "Expected matching: \n%s\nLogs received: \n%s",
       expectedLogMessage.toString(),
       logEvents.stream()
         .map(VerificationException::formatLogEvent)

--- a/src/test/java/com/logcapture/LogCaptureShould.java
+++ b/src/test/java/com/logcapture/LogCaptureShould.java
@@ -2,6 +2,7 @@ package com.logcapture;
 
 import com.logcapture.assertion.VerificationException;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,11 +22,30 @@ import static com.logcapture.matcher.exception.ExceptionCauseMessageMatcher.wher
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class LogCaptureShould {
   private static final String LOG_NAME = "aLogNotAttachedToRoot";
   private final Logger log = LoggerFactory.getLogger(LogCaptureShould.class);
+
+  @Test
+  public void verify_missing_events() {
+    captureLogEvents(() -> log.info("a message"))
+      .logged(not(aLog()
+        .withLevel(equalTo(INFO))
+        .withMessage(equalTo("missing message"))));
+  }
+
+  @Test
+  public void verify_multiple_events() {
+    captureLogEvents(() -> {
+      log.info("first message");
+      log.debug("second message");})
+      .logged(allOf(aLog().withLevel(equalTo(INFO)).withMessage(equalTo("first message")),
+        aLog().withLevel(equalTo(DEBUG)).withMessage(equalTo("second message"))));
+  }
 
   @Test
   public void verify_captured_events() {

--- a/src/test/java/com/logcapture/assertion/ExpectedLoggingMessageShould.java
+++ b/src/test/java/com/logcapture/assertion/ExpectedLoggingMessageShould.java
@@ -15,6 +15,9 @@ import static ch.qos.logback.classic.Level.WARN;
 import static com.logcapture.assertion.ExpectedLoggedException.logException;
 import static com.logcapture.assertion.ExpectedLoggingMessage.aLog;
 import static com.logcapture.matcher.exception.ExceptionCauseMatcher.causeOf;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -23,11 +26,42 @@ import static org.hamcrest.Matchers.instanceOf;
 public class ExpectedLoggingMessageShould {
 
   @Test
+  public void match_when_at_least_one_element_is_matching() {
+    LoggingEvent matchingEvent = aLoggingEventWith(INFO, "message");
+    LoggingEvent notMatchingEvent = aLoggingEventWith(INFO, "message");
+    ExpectedLoggingMessage expectedLoggingMessage = aLog().withLevel(equalTo(INFO));
+
+    boolean matches = expectedLoggingMessage.matches(asList(matchingEvent, notMatchingEvent));
+
+    assertThat(matches).isTrue();
+  }
+
+  @Test
+  public void no_match_when_there_are_no_events() {
+    ExpectedLoggingMessage expectedLoggingMessage = aLog().withLevel(equalTo(INFO));
+
+    boolean matches = expectedLoggingMessage.matches(emptyList());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  public void not_match_when_no_element_is_matching() {
+    LoggingEvent notMatchingEvent1 = aLoggingEventWith(INFO, "message");
+    LoggingEvent notMatchingEvent2 = aLoggingEventWith(INFO, "message");
+    ExpectedLoggingMessage expectedLoggingMessage = aLog().withLevel(equalTo(DEBUG));
+
+    boolean matches = expectedLoggingMessage.matches(asList(notMatchingEvent1, notMatchingEvent2));
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
   public void match_when_log_level_match() {
     LoggingEvent logEvent = aLoggingEventWith(INFO, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().withLevel(equalTo(INFO));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -37,7 +71,7 @@ public class ExpectedLoggingMessageShould {
     LoggingEvent logEvent = aLoggingEventWith(DEBUG, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().debug();
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -47,7 +81,7 @@ public class ExpectedLoggingMessageShould {
     LoggingEvent logEvent = aLoggingEventWith(INFO, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().info();
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -57,7 +91,7 @@ public class ExpectedLoggingMessageShould {
     LoggingEvent logEvent = aLoggingEventWith(WARN, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().warn();
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -67,7 +101,7 @@ public class ExpectedLoggingMessageShould {
     LoggingEvent logEvent = aLoggingEventWith(ERROR, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().error();
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -77,7 +111,7 @@ public class ExpectedLoggingMessageShould {
     LoggingEvent logEvent = aLoggingEventWith(INFO, "message");
     ExpectedLoggingMessage expectedLoggingMessage = aLog().withMessage(equalTo("message"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -91,7 +125,7 @@ public class ExpectedLoggingMessageShould {
       containsString("another")
     );
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -106,7 +140,7 @@ public class ExpectedLoggingMessageShould {
       containsString("another")
     );
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }
@@ -117,7 +151,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .length(equalTo(7));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -129,7 +163,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMdc("aKey", equalTo("someValue"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -143,7 +177,7 @@ public class ExpectedLoggingMessageShould {
       .withMdc("aKey", equalTo("someValue"))
       .withMdc("anotherKey", equalTo("anotherValue"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -154,7 +188,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withLoggerName(equalTo(ExpectedLoggingMessageShould.class.getName()));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -166,7 +200,7 @@ public class ExpectedLoggingMessageShould {
       .havingException(logException()
         .withException(instanceOf(RuntimeException.class)));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -178,7 +212,7 @@ public class ExpectedLoggingMessageShould {
       .withLevel(equalTo(INFO))
       .withMessage(equalTo("message"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -189,7 +223,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMessage(equalTo("differentMessage"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }
@@ -200,7 +234,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMessage(equalTo("anotherMessage"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }
@@ -211,7 +245,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .length(equalTo(8));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }
@@ -223,7 +257,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMdc("aKey", equalTo("someValue"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     MDC.clear();
     assertThat(matches).isFalse();
@@ -238,7 +272,7 @@ public class ExpectedLoggingMessageShould {
       .withMdc("aKey", equalTo("unmatchedValue"))
       .withMdc("anotherKey", equalTo("anotherValue"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     MDC.clear();
     assertThat(matches).isFalse();
@@ -250,7 +284,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withLoggerName(equalTo("anotherClassName"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }
@@ -263,7 +297,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMarker(MarkerFactory.getMarker("A_MARKER"));
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -276,7 +310,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMarker("A_MARKER");
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isTrue();
   }
@@ -289,7 +323,7 @@ public class ExpectedLoggingMessageShould {
     ExpectedLoggingMessage expectedLoggingMessage = aLog()
       .withMarker("ANOTHER_MARKER");
 
-    boolean matches = expectedLoggingMessage.matches(logEvent);
+    boolean matches = expectedLoggingMessage.matches(singletonList(logEvent));
 
     assertThat(matches).isFalse();
   }

--- a/src/test/java/com/logcapture/assertion/VerificationExceptionShould.java
+++ b/src/test/java/com/logcapture/assertion/VerificationExceptionShould.java
@@ -30,7 +30,7 @@ public class VerificationExceptionShould {
 
     VerificationException verificationException = VerificationException.forUnmatchedLog(expectedLogMessage, logEvents);
 
-    assertThat(verificationException.toString()).isEqualTo("com.logcapture.assertion.VerificationException: Expected at least one log matching: \n" +
+    assertThat(verificationException.toString()).isEqualTo("com.logcapture.assertion.VerificationException: Expected matching: \n" +
       "ExpectedLoggingMessage{logLevelMatcher=<INFO>, expectedMessageMatcher=[\"a log message\"], expectedMdc={}}\n" +
       "Logs received: \n" +
       "level: INFO marker: null mdc: {} message: a different message\n" +
@@ -56,7 +56,7 @@ public class VerificationExceptionShould {
 
     VerificationException verificationException = VerificationException.forUnmatchedLog(expectedLogMessage, logEvents);
 
-    assertThat(verificationException.toString()).isEqualTo("com.logcapture.assertion.VerificationException: Expected at least one log matching: \n" +
+    assertThat(verificationException.toString()).isEqualTo("com.logcapture.assertion.VerificationException: Expected matching: \n" +
       "ExpectedLoggingMessage{logLevelMatcher=<INFO>, expectedMessageMatcher=[\"a log message\"], expectedMdc={anotherKey=\"anotherValue\", aKey=\"aValue\"}}\n" +
       "Logs received: \n" +
       "level: INFO marker: null mdc: {anotherKey=anotherValue, aKey=aValue} message: a different message\n" +

--- a/src/test/java/com/logcapture/assertion/VerificationExceptionShould.java
+++ b/src/test/java/com/logcapture/assertion/VerificationExceptionShould.java
@@ -13,7 +13,9 @@ import java.util.List;
 import java.util.Map;
 
 import static com.logcapture.assertion.ExpectedLoggingMessage.aLog;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VerificationExceptionShould {
@@ -63,7 +65,9 @@ public class VerificationExceptionShould {
 
   private LoggingEvent aLoggingEventWith(Level level, String message) {
     Logger log = (Logger) LoggerFactory.getLogger(getClass());
-    return new LoggingEvent("fqcn", log, level, message, null, null);
+    LoggingEvent loggingEvent = new LoggingEvent("fqcn", log, level, message, null, null);
+    loggingEvent.setMDCPropertyMap(emptyMap());
+    return loggingEvent;
   }
 
   private LoggingEvent aLoggingEventWith(Level level, String message, Map<String, String> mdcKeys) {


### PR DESCRIPTION
I think the MDC when you create a log event gets some static magic so if you don't have one to avoid magic you can just pass in an empty map.
The failure I guess depends on the order run.